### PR TITLE
Moves jpeg and png pkgs from Suggests: to Imports:

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,10 +13,10 @@ LazyData: TRUE
 Depends:
     R (>= 2.1.0)
 Imports:
-    ggplot2
-Suggests:
-    testthat,
-    scales,
+    ggplot2,
     jpeg,
     png
+Suggests:
+    testthat,
+    scales
 


### PR DESCRIPTION
This commit moves the `jpeg` and `png` packages from Suggests: to Imports: as one of them is required to read in an image before it can be handed off to `image_palette()`.
