### PR TITLE
Use nearest-neighbour lookup?

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,10 +13,10 @@ LazyData: TRUE
 Depends:
     R (>= 2.1.0)
 Imports:
-    ggplot2
+    ggplot2,
+    RANN
 Suggests:
     testthat,
     scales,
     jpeg,
     png
-

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(RImagePalette)
+
+test_check("RImagePalette")

--- a/tests/testthat/test-quantize.R
+++ b/tests/testthat/test-quantize.R
@@ -1,0 +1,16 @@
+context("test-quantize")
+img <- jpeg::readJPEG(system.file("img", "Rlogo.jpg", package="jpeg"))
+set.seed(10)
+quant_img <- quantize_image(img, n=3)
+
+# set.seed(10)
+# dput(unique(as.vector(quant_img)))
+
+bench <- sort(c(0.937254901960784, 0.525490196078431, 0.329411764705882, 0.945098039215686,
+                0.568627450980392, 0.349019607843137, 0.952941176470588, 0.63921568627451,
+                0.36078431372549))
+
+test_that("quantize image works", {
+  expect_equal(sort(unique(as.vector(quant_img))), bench)
+  expect_that(dim(quant_img), equals(c(76L, 100L, 3L)))
+})


### PR DESCRIPTION
This requires adding package RANN to Imports, but provides a pretty significant speed up for quantize_image. 

I separated the nn lookup into `index_palette()` so it can be used separately from the image handling in this package. 

I added a very basic testthat test. 